### PR TITLE
屈折点がレンズの大きさより外側にある場合では計算が失敗するように変更

### DIFF
--- a/matlab/simulate_ray_propagation_through_the_lens.m
+++ b/matlab/simulate_ray_propagation_through_the_lens.m
@@ -90,6 +90,9 @@ function refracted_ray = calc_refraction_ray(incident_ray, lens, air, surface_si
     if ~isreal(intersection.x)
         refracted_ray = [];
         return;
+    elseif abs(intersection.y) > abs(lens.radius)
+        refracted_ray = [];
+        return;
     end
     
     %% 交点における屈折角を計算


### PR DESCRIPTION
忘れてた